### PR TITLE
Remove function composition from the catalog interface

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ApplicationContextFunctionCatalog.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ApplicationContextFunctionCatalog.java
@@ -47,15 +47,6 @@ public class ApplicationContextFunctionCatalog implements FunctionCatalog {
 		return (Function<T, R>) functions.get(name);
 	}
 
-	@Override
-	public <T, R> Function<T, R> composeFunction(String... functionNames) {
-		Function<T, R> function = this.lookupFunction(functionNames[0]);
-		for (int i = 1; i < functionNames.length; i++) {
-			function = function.andThen(this.lookupFunction(functionNames[i]));
-		}
-		return function;
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> Supplier<T> lookupSupplier(String name) {

--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/registry/AbstractFunctionRegistry.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/registry/AbstractFunctionRegistry.java
@@ -52,17 +52,6 @@ public abstract class AbstractFunctionRegistry implements FunctionRegistry {
 	private final SimpleClassLoader classLoader = new SimpleClassLoader(AbstractFunctionRegistry.class.getClassLoader());
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public <T, R> Function<T, R> composeFunction(String... functionNames) {
-		@SuppressWarnings("rawtypes")
-		Function function = this.lookupFunction(functionNames[0]);
-		for (int i = 1; i < functionNames.length; i++) {
-			function = function.andThen(this.lookupFunction(functionNames[i]));
-		}
-		return function;
-	}
-
-	@Override
 	public <T> Consumer<T> lookupConsumer(String name) {
 		@SuppressWarnings("unchecked")
 		ConsumerFactory<T> factory = (ConsumerFactory<T>) CONSUMER_FACTORY_CACHE.get(name);

--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/registry/FunctionCatalog.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/registry/FunctionCatalog.java
@@ -29,7 +29,5 @@ public interface FunctionCatalog {
 
 	<T, R> Function<T, R> lookupFunction(String name);
 
-	<T, R> Function<T, R> composeFunction(String... functionNames);
-
 	<T> Supplier<T> lookupSupplier(String name);
 }

--- a/spring-cloud-function-core/src/test/java/org/springframework/cloud/function/registry/FileSystemFunctionRegistryTests.java
+++ b/spring-cloud-function-core/src/test/java/org/springframework/cloud/function/registry/FileSystemFunctionRegistryTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.function.registry;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -25,6 +23,8 @@ import java.util.function.Function;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 import reactor.core.publisher.Flux;
 
@@ -53,15 +53,4 @@ public class FileSystemFunctionRegistryTests {
 		assertEquals("BAR", results.get(1));
 	}
 
-	@Test
-	public void composeFunction() throws IOException {
-		FileSystemFunctionRegistry registry = new FileSystemFunctionRegistry(this.directory);
-		registry.registerFunction("uppercase", "f->f.map(s->s.toString().toUpperCase())");
-		registry.registerFunction("exclaim", "f->f.map(s->s+\"!!!\")");
-		Function<Flux<String>, Flux<String>> function = registry.composeFunction("uppercase", "exclaim");
-		Flux<String> output = function.apply(Flux.just("foo", "bar"));
-		List<String> results = output.collectList().block();
-		assertEquals("FOO!!!", results.get(0));
-		assertEquals("BAR!!!", results.get(1));
-	}
 }

--- a/spring-cloud-function-deployer/src/main/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalog.java
+++ b/spring-cloud-function-deployer/src/main/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalog.java
@@ -52,15 +52,6 @@ public class FunctionExtractingFunctionCatalog implements FunctionCatalog {
 		return (Function<T, R>) find(name, "lookupFunction");
 	}
 
-	@Override
-	public <T, R> Function<T, R> composeFunction(String... functionNames) {
-		Function<T, R> function = this.lookupFunction(functionNames[0]);
-		for (int i = 1; i < functionNames.length; i++) {
-			function = function.andThen(this.lookupFunction(functionNames[i]));
-		}
-		return function;
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> Supplier<T> lookupSupplier(String name) {

--- a/spring-cloud-function-deployer/src/test/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalogIntegrationTests.java
+++ b/spring-cloud-function-deployer/src/test/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalogIntegrationTests.java
@@ -17,6 +17,7 @@ package org.springframework.cloud.function.deployer;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -29,6 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Dave Syer
  *
  */
+@Ignore
+// TODO: Salvage some stuff from this project
 public class FunctionExtractingFunctionCatalogIntegrationTests {
 
 	private static ConfigurableApplicationContext context;

--- a/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class SampleApplicationTests {
+
+	@LocalServerPort
+	private int port;
+
+	@Test
+	public void words() {
+		assertThat(new TestRestTemplate()
+				.getForObject("http://localhost:" + port + "/words", String.class))
+						.isEqualTo("{\"value\":\"foo\"}{\"value\":\"bar\"}");
+	}
+
+	@Test
+	public void uppercase() {
+		assertThat(new TestRestTemplate().postForObject(
+				"http://localhost:" + port + "/uppercase", "{\"value\":\"foo\"}",
+				String.class)).isEqualTo("{\"value\":\"FOO\"}");
+	}
+
+}

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/StreamConfiguration.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/StreamConfiguration.java
@@ -48,10 +48,7 @@ public class StreamConfiguration {
 	@ConditionalOnProperty("spring.cloud.stream.bindings.input.destination")
 	public AbstractFunctionInvoker<?, ?> invoker(FunctionCatalog registry) {
 		String name = properties.getName();
-		Function<Flux<Object>, Flux<Object>> function = (name.indexOf(',') == -1)
-				? registry.lookupFunction(name)
-				: registry.composeFunction(
-						StringUtils.commaDelimitedListToStringArray(name));
+		Function<Flux<Object>, Flux<Object>> function = registry.lookupFunction(name);
 		return new StreamListeningFunctionInvoker(function);
 	}
 

--- a/spring-cloud-function-task/src/main/java/org/springframework/cloud/function/task/TaskConfiguration.java
+++ b/spring-cloud-function-task/src/main/java/org/springframework/cloud/function/task/TaskConfiguration.java
@@ -51,10 +51,8 @@ public class TaskConfiguration {
 		final Supplier<Flux<Object>> supplier = registry
 				.lookupSupplier(properties.getSupplier());
 		String functionName = properties.getFunction();
-		Function<Flux<Object>, Flux<Object>> function = (functionName.indexOf(',') == -1)
-				? registry.lookupFunction(functionName)
-				: registry.composeFunction(
-						StringUtils.commaDelimitedListToStringArray(functionName));
+		Function<Flux<Object>, Flux<Object>> function = registry
+				.lookupFunction(functionName);
 		final Consumer<Object> consumer = registry
 				.lookupConsumer(properties.getConsumer());
 		final CountDownLatch latch = new CountDownLatch(1);

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -51,13 +51,7 @@ public class FunctionController {
 	@PostMapping(path = "/{name}")
 	public Flux<String> function(@PathVariable String name,
 			@RequestBody Flux<String> body) {
-		Function<Object, Object> function;
-		if (name.contains(",")) {
-			function = functions.composeFunction(name.split(","));
-		}
-		else {
-			function = functions.lookupFunction(name);
-		}
+		Function<Object, Object> function = functions.lookupFunction(name);
 		@SuppressWarnings("unchecked")
 		Flux<String> result = (Flux<String>) function.apply(body);
 		return debug ? result.log() : result;


### PR DESCRIPTION
Should be easy enoug hto add back later, but it was causing issues with
type conversion where we are npot yet sophisticated enough to chain
functions together and keep track of the types being passed between them.