### PR TITLE
If HTTP client asks for JSON, then time out the response

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -70,6 +70,7 @@ public class FunctionController {
 	}
 
 	@GetMapping(path = "/{name}")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Flux<String> supplier(@PathVariable String name) {
 		Supplier<Object> supplier = functions.lookupSupplier(name);
 		if (!FunctionUtils.isFluxSupplier(supplier)) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.function.web.flux;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpResponse;
@@ -38,9 +40,10 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 
 	public FluxResponseBodyEmitter(Long timeout, MediaType mediaType,
 			Flux<T> observable) {
-		super(timeout);
+		super();
 		this.mediaType = mediaType;
-		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
+		new ResponseBodyEmitterSubscriber<>(mediaType,
+				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
 	}
 
 	@Override
@@ -48,7 +51,8 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 		super.extendResponse(outputMessage);
 
 		HttpHeaders headers = outputMessage.getHeaders();
-		if (headers.getContentType() == null && this.mediaType!=null && !MediaType.ALL.equals(this.mediaType)) {
+		if (headers.getContentType() == null && this.mediaType != null
+				&& !MediaType.ALL.equals(this.mediaType)) {
 			headers.setContentType(this.mediaType);
 		}
 	}

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.function.web.flux;
 
+import java.time.Duration;
+
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -35,8 +37,9 @@ class FluxResponseSseEmitter<T> extends SseEmitter {
 	}
 
 	public FluxResponseSseEmitter(Long timeout, MediaType mediaType, Flux<T> observable) {
-		super(timeout);
-		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
+		super();
+		new ResponseBodyEmitterSubscriber<>(mediaType,
+				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
 	}
 
 }

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -91,6 +91,14 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void timeoutJson() throws Exception {
+		assertThat(rest
+				.exchange(RequestEntity.get(new URI("/timeout"))
+						.accept(MediaType.APPLICATION_JSON).build(), String.class)
+				.getBody()).isEqualTo("[\"foo\"]");
+	}
+
+	@Test
 	public void emptyJson() throws Exception {
 		assertThat(rest
 				.exchange(RequestEntity.get(new URI("/empty"))
@@ -211,6 +219,13 @@ public class RestApplicationTests {
 		@Bean
 		public Supplier<Flux<String>> empty() {
 			return () -> Flux.fromIterable(Collections.emptyList());
+		}
+
+		@Bean
+		public Supplier<Flux<String>> timeout() {
+			return () -> Flux.create(emitter -> {
+				emitter.next("foo");
+			});
 		}
 
 		@Bean


### PR DESCRIPTION
An HTTP response does not have to be an infinite stream, and in fact life
is simpler if it is not. The timeout in the web wrappers can be used to
close the response and return normally to a client that has been waiting
more than (say) 1s, instead of treating it as an error condition.

Error handling is still kind of unsolved.