### PR TITLE
Resort to reflection if the function is not a @Bean

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -70,6 +70,7 @@ public class FunctionController {
 	}
 
 	@GetMapping(path = "/{name}")
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public Flux<String> supplier(@PathVariable String name) {
 		Supplier<Object> supplier = functions.lookupSupplier(name);
 		if (!FunctionUtils.isFluxSupplier(supplier)) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -79,4 +79,15 @@ public class FunctionController {
 		Flux<String> result = (Flux<String>) supplier.get();
 		return debug ? result.log() : result;
 	}
+
+	@GetMapping(path = "/{name}/{value}")
+	public Flux<String> value(@PathVariable String name, @PathVariable String value) {
+		Function<Flux<?>, Flux<?>> function = functions.lookupFunction(name);
+		if (function != null) {
+			@SuppressWarnings({ "unchecked" })
+			Flux<String> result = (Flux<String>) function.apply(Flux.just(value));
+			return debug ? result.log() : result;
+		}
+		throw new IllegalArgumentException("no such function: " + name);
+	}
 }

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.function.web.flux;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.ServerHttpResponse;
@@ -38,9 +40,10 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 
 	public FluxResponseBodyEmitter(Long timeout, MediaType mediaType,
 			Flux<T> observable) {
-		super(timeout);
+		super();
 		this.mediaType = mediaType;
-		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
+		new ResponseBodyEmitterSubscriber<>(mediaType,
+				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
 	}
 
 	@Override
@@ -48,7 +51,8 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 		super.extendResponse(outputMessage);
 
 		HttpHeaders headers = outputMessage.getHeaders();
-		if (headers.getContentType() == null && this.mediaType!=null && !MediaType.ALL.equals(this.mediaType)) {
+		if (headers.getContentType() == null && this.mediaType != null
+				&& !MediaType.ALL.equals(this.mediaType)) {
 			headers.setContentType(this.mediaType);
 		}
 	}

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.function.web.flux;
 
+import java.time.Duration;
+
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -35,8 +37,9 @@ class FluxResponseSseEmitter<T> extends SseEmitter {
 	}
 
 	public FluxResponseSseEmitter(Long timeout, MediaType mediaType, Flux<T> observable) {
-		super(timeout);
-		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
+		super();
+		new ResponseBodyEmitterSubscriber<>(mediaType,
+				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
 	}
 
 }

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -91,6 +91,14 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void timeoutJson() throws Exception {
+		assertThat(rest
+				.exchange(RequestEntity.get(new URI("/timeout"))
+						.accept(MediaType.APPLICATION_JSON).build(), String.class)
+				.getBody()).isEqualTo("[\"foo\"]");
+	}
+
+	@Test
 	public void emptyJson() throws Exception {
 		assertThat(rest
 				.exchange(RequestEntity.get(new URI("/empty"))
@@ -211,6 +219,13 @@ public class RestApplicationTests {
 		@Bean
 		public Supplier<Flux<String>> empty() {
 			return () -> Flux.fromIterable(Collections.emptyList());
+		}
+
+		@Bean
+		public Supplier<Flux<String>> timeout() {
+			return () -> Flux.create(emitter -> {
+				emitter.next("foo");
+			});
 		}
 
 		@Bean

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -151,6 +151,16 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void uppercaseGet() {
+		assertThat(rest.getForObject("/uppercase/foo", String.class)).isEqualTo("[FOO]");
+	}
+
+	@Test
+	public void convertGet() {
+		assertThat(rest.getForObject("/wrap/123", String.class)).isEqualTo("..123..");
+	}
+
+	@Test
 	public void uppercaseJsonArray() throws Exception {
 		assertThat(rest.exchange(
 				RequestEntity.post(new URI("/maps"))
@@ -191,6 +201,11 @@ public class RestApplicationTests {
 		public Function<Flux<String>, Flux<String>> uppercase() {
 			return flux -> flux.log()
 					.map(value -> "[" + value.trim().toUpperCase() + "]");
+		}
+
+		@Bean
+		public Function<Flux<Integer>, Flux<String>> wrap() {
+			return flux -> flux.log().map(value -> ".." + value + "..");
 		}
 
 		@Bean


### PR DESCRIPTION
Beans that are not created from a @Bean factory method do not have the same
kind of metadata. This change uses relection to extract the target type
from the bean definition if all else fails.