### PR TITLE
Make GET /{function}/{value} single valued (Mono)

### DIFF
--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import reactor.core.publisher.Flux;
@@ -40,6 +41,7 @@ import reactor.core.publisher.Flux;
  */
 @RestController
 @ConditionalOnClass(RestController.class)
+@RequestMapping("${spring.cloud.function.web.path:}")
 public class FunctionController {
 
 	@Value("${debug:${DEBUG:false}}")

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Dave Syer
@@ -83,11 +84,12 @@ public class FunctionController {
 	}
 
 	@GetMapping(path = "/{name}/{value}")
-	public Flux<String> value(@PathVariable String name, @PathVariable String value) {
+	public Mono<String> value(@PathVariable String name, @PathVariable String value) {
 		Function<Flux<?>, Flux<?>> function = functions.lookupFunction(name);
 		if (function != null) {
 			@SuppressWarnings({ "unchecked" })
-			Flux<String> result = (Flux<String>) function.apply(Flux.just(value));
+			Mono<String> result = Mono
+					.from((Flux<String>) function.apply(Flux.just(value)));
 			return debug ? result.log() : result;
 		}
 		throw new IllegalArgumentException("no such function: " + name);

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
@@ -35,7 +35,7 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 	private final MediaType mediaType;
 
 	public FluxResponseBodyEmitter(Flux<T> observable) {
-		this(null, null, observable);
+		this(1000L, null, observable);
 	}
 
 	public FluxResponseBodyEmitter(Long timeout, MediaType mediaType,

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.function.web.flux;
 
-import java.time.Duration;
+import org.reactivestreams.Publisher;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -34,16 +34,14 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 
 	private final MediaType mediaType;
 
-	public FluxResponseBodyEmitter(Flux<T> observable) {
-		this(1000L, null, observable);
+	public FluxResponseBodyEmitter(Publisher<T> observable) {
+		this(null, observable);
 	}
 
-	public FluxResponseBodyEmitter(Long timeout, MediaType mediaType,
-			Flux<T> observable) {
+	public FluxResponseBodyEmitter(MediaType mediaType, Publisher<T> observable) {
 		super();
 		this.mediaType = mediaType;
-		new ResponseBodyEmitterSubscriber<>(mediaType,
-				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
+		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
 	}
 
 	@Override

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseSseEmitter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.function.web.flux;
 
-import java.time.Duration;
+import org.reactivestreams.Publisher;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
@@ -32,14 +32,13 @@ import reactor.core.publisher.Flux;
  */
 class FluxResponseSseEmitter<T> extends SseEmitter {
 
-	public FluxResponseSseEmitter(Flux<T> observable) {
-		this(null, MediaType.valueOf("text/event-stream"), observable);
+	public FluxResponseSseEmitter(Publisher<T> observable) {
+		this(MediaType.valueOf("text/event-stream"), observable);
 	}
 
-	public FluxResponseSseEmitter(Long timeout, MediaType mediaType, Flux<T> observable) {
+	public FluxResponseSseEmitter(MediaType mediaType, Publisher<T> observable) {
 		super();
-		new ResponseBodyEmitterSubscriber<>(mediaType,
-				observable.timeout(Duration.ofMillis(timeout), Flux.empty()), this);
+		new ResponseBodyEmitterSubscriber<>(mediaType, observable, this);
 	}
 
 }

--- a/spring-cloud-function-web/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-function-web/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{"properties": [
+  {
+    "name": "spring.cloud.function.web.path",
+    "type": "java.lang.String",
+    "description": "Path to web resources for functions (should start with / if not empty).",
+    "defaultValue": ""
+  }]
+}
+

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -161,6 +161,14 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void convertGetJson() throws Exception {
+		assertThat(rest
+				.exchange(RequestEntity.get(new URI("/entity/321"))
+						.accept(MediaType.APPLICATION_JSON).build(), String.class)
+				.getBody()).isEqualTo("{\"value\":321}");
+	}
+
+	@Test
 	public void uppercaseJsonArray() throws Exception {
 		assertThat(rest.exchange(
 				RequestEntity.post(new URI("/maps"))
@@ -206,6 +214,12 @@ public class RestApplicationTests {
 		@Bean
 		public Function<Flux<Integer>, Flux<String>> wrap() {
 			return flux -> flux.log().map(value -> ".." + value + "..");
+		}
+
+		@Bean
+		public Function<Flux<Integer>, Flux<Map<String, Object>>> entity() {
+			return flux -> flux.log()
+					.map(value -> Collections.singletonMap("value", value));
 		}
 
 		@Bean


### PR DESCRIPTION
When the user has sent us a single value, we can make the signature of the
handler and the format of the HTTP response much more natural if it is
single valued too (i.e. a Mono).