### PR TITLE
Extend support for simple types to Consumer and Supplier

### DIFF
--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfiguration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfiguration.java
@@ -98,54 +98,78 @@ public class ContextFunctionCatalogAutoConfiguration {
 				Map<String, Supplier<?>> suppliers) {
 			Map<String, Supplier<?>> result = new HashMap<>();
 			for (String key : suppliers.keySet()) {
-				if (this.suppliers.contains(key)) {
-					@SuppressWarnings("unchecked")
-					Supplier<Flux<?>> supplier = (Supplier<Flux<?>>) suppliers.get(key);
-					result.put(key, wrapSupplier(supplier, mapper, key));
-				}
-				else {
-					result.put(key, suppliers.get(key));
+				Supplier<?> target = target(suppliers.get(key), mapper, key);
+				result.put(key, target);
+				for (String name : registry.getAliases(key)) {
+					result.put(name, target);
 				}
 			}
 			return result;
+		}
+
+		private Supplier<?> target(Supplier<?> target, ObjectMapper mapper, String key) {
+			if (this.suppliers.contains(key)) {
+				@SuppressWarnings("unchecked")
+				Supplier<Flux<?>> supplier = (Supplier<Flux<?>>) target;
+				return wrapSupplier(supplier, mapper, key);
+			}
+			else {
+				return target;
+			}
 		}
 
 		public Map<String, Function<?, ?>> wrapFunctions(ObjectMapper mapper,
 				Map<String, Function<?, ?>> functions) {
 			Map<String, Function<?, ?>> result = new HashMap<>();
 			for (String key : functions.keySet()) {
-				if (this.functions.contains(key)) {
-					@SuppressWarnings("unchecked")
-					Function<Flux<?>, Flux<?>> function = (Function<Flux<?>, Flux<?>>) functions
-							.get(key);
-					result.put(key, wrapFunction(function, mapper, key));
-				}
-				else if (!isFluxFunction(key, functions.get(key))) {
-					@SuppressWarnings({ "unchecked", "rawtypes" })
-					FluxFunction value = new FluxFunction(functions.get(key));
-					result.put(key, value);
-				}
-				else {
-					result.put(key, functions.get(key));
+				Function<?, ?> target = target(functions.get(key), mapper, key);
+				result.put(key, target);
+				for (String name : registry.getAliases(key)) {
+					result.put(name, target);
 				}
 			}
 			return result;
+		}
+
+		private Function<?, ?> target(Function<?, ?> target, ObjectMapper mapper,
+				String key) {
+			if (this.functions.contains(key)) {
+				@SuppressWarnings("unchecked")
+				Function<Flux<?>, Flux<?>> function = (Function<Flux<?>, Flux<?>>) target;
+				return wrapFunction(function, mapper, key);
+			}
+			else if (!isFluxFunction(key, target)) {
+				@SuppressWarnings({ "unchecked", "rawtypes" })
+				FluxFunction value = new FluxFunction(target);
+				return value;
+			}
+			else {
+				return target;
+			}
 		}
 
 		public Map<String, Consumer<?>> wrapConsumers(ObjectMapper mapper,
 				Map<String, Consumer<?>> consumers) {
 			Map<String, Consumer<?>> result = new HashMap<>();
 			for (String key : consumers.keySet()) {
-				if (this.consumers.contains(key)) {
-					@SuppressWarnings("unchecked")
-					Consumer<Flux<?>> consumer = (Consumer<Flux<?>>) consumers.get(key);
-					result.put(key, wrapConsumer(consumer, mapper, key));
-				}
-				else {
-					result.put(key, consumers.get(key));
+				Consumer<?> target = target(consumers.get(key), mapper, key);
+				result.put(key, target);
+				for (String name : registry.getAliases(key)) {
+					result.put(name, target);
 				}
 			}
 			return result;
+		}
+
+		private Consumer<?> target(Consumer<?> target, ObjectMapper mapper, String key) {
+			if (this.consumers.contains(key)) {
+				@SuppressWarnings("unchecked")
+				Consumer<Flux<?>> consumer = (Consumer<Flux<?>>) target;
+				return wrapConsumer(consumer, mapper, key);
+			}
+			else {
+				return target;
+			}
 		}
 
 		@Override

--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/ConsumerProxy.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/ConsumerProxy.java
@@ -16,29 +16,18 @@
 
 package org.springframework.cloud.function.support;
 
-import java.util.function.Function;
-
-import reactor.core.publisher.Flux;
+import java.util.function.Consumer;
 
 /**
- * {@link Function} implementation that wraps a target Function so that the target's
- * simple input and output types will be wrapped as {@link Flux} instances.
- *
  * @author Mark Fisher
  *
- * @param <T> input type of target function
- * @param <R> output type of target function
+ * @param <T> output type of target Consumer
  */
-public class FluxFunction<T, R> implements Function<Flux<T>, Flux<R>> {
+public interface ConsumerProxy<T> extends Consumer<T> {
 
-	private final Function<T, R> function;
-
-	public FluxFunction(Function<T, R> function) {
-		this.function = function;
+	default boolean isFluxConsumer() {
+		return FunctionUtils.isFluxConsumer(getTarget());
 	}
 
-	@Override
-	public Flux<R> apply(Flux<T> input) {
-		return input.map(i -> this.function.apply(i));
-	}
+	Consumer<T> getTarget();
 }

--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/FluxConsumer.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/FluxConsumer.java
@@ -16,29 +16,28 @@
 
 package org.springframework.cloud.function.support;
 
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import reactor.core.publisher.Flux;
 
 /**
- * {@link Function} implementation that wraps a target Function so that the target's
- * simple input and output types will be wrapped as {@link Flux} instances.
+ * {@link Consumer} implementation that wraps a target Consumer so that the target's
+ * simple input type will be wrapped as a {@link Flux} instance.
  *
- * @author Mark Fisher
+ * @author Dave Syer
  *
- * @param <T> input type of target function
- * @param <R> output type of target function
+ * @param <T> input type of target consumer
  */
-public class FluxFunction<T, R> implements Function<Flux<T>, Flux<R>> {
+public class FluxConsumer<T> implements Consumer<Flux<T>> {
 
-	private final Function<T, R> function;
+	private final Consumer<T> function;
 
-	public FluxFunction(Function<T, R> function) {
+	public FluxConsumer(Consumer<T> function) {
 		this.function = function;
 	}
 
 	@Override
-	public Flux<R> apply(Flux<T> input) {
-		return input.map(i -> this.function.apply(i));
+	public void accept(Flux<T> input) {
+		input.subscribe(t -> function.accept(t));
 	}
 }

--- a/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/main/java/com/example/SampleApplication.java
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/main/java/com/example/SampleApplication.java
@@ -15,6 +15,9 @@
 */
 package com.example;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -27,9 +30,20 @@ import reactor.core.publisher.Flux;
 @SpringBootApplication
 public class SampleApplication {
 
+	private List<Foo> list = new ArrayList<>();
+
+	public List<Foo> getList() {
+		return list;
+	}
+
 	@Bean
 	public Function<Flux<Foo>, Flux<Bar>> uppercase() {
 		return flux -> flux.map(value -> new Bar(value.uppercase()));
+	}
+
+	@Bean
+	public Consumer<Flux<Foo>> async() {
+		return flux -> flux.log().subscribe(value -> list.add(value));
 	}
 
 	@Bean

--- a/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-pojo/src/test/java/com/example/SampleApplicationTests.java
@@ -18,10 +18,13 @@ package com.example;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +40,9 @@ public class SampleApplicationTests {
 	@LocalServerPort
 	private int port;
 
+	@Autowired
+	private SampleApplication app;
+
 	@Test
 	public void words() {
 		assertThat(new TestRestTemplate()
@@ -49,6 +55,16 @@ public class SampleApplicationTests {
 		assertThat(new TestRestTemplate().postForObject(
 				"http://localhost:" + port + "/uppercase", "{\"value\":\"foo\"}",
 				String.class)).isEqualTo("{\"value\":\"FOO\"}");
+	}
+
+	@Test
+	public void async() {
+		ResponseEntity<String> post = new TestRestTemplate().postForEntity(
+				"http://localhost:" + port + "/async", "{\"value\":\"foo\"}",
+				String.class);
+		assertThat(post.getBody()).isEqualTo("{\"value\":\"foo\"}");
+		assertThat(post.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+		assertThat(app.getList()).hasSize(1);
 	}
 
 }

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -64,9 +64,9 @@ public class FunctionController {
 			Flux<String> result = (Flux<String>) function.apply(body);
 			return debug ? result.log() : result;
 		}
-		Consumer<String> consumer = functions.lookupConsumer(name);
+		Consumer<Flux<?>> consumer = functions.lookupConsumer(name);
 		if (consumer != null) {
-			body.subscribe(consumer::accept);
+			consumer.accept(body);
 			return null;
 		}
 		throw new IllegalArgumentException("no such function: " + name);

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/FunctionController.java
@@ -24,8 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.function.registry.FunctionCatalog;
-import org.springframework.cloud.function.support.FluxSupplier;
-import org.springframework.cloud.function.support.FunctionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -103,14 +101,11 @@ public class FunctionController {
 		return supplier(name + suffix);
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({ "unchecked" })
 	private Flux<String> supplier(@PathVariable String name) {
 		Supplier<Object> supplier = functions.lookupSupplier(name);
 		if (supplier == null) {
 			throw new IllegalArgumentException("no such supplier: " + name);
-		}
-		if (!FunctionUtils.isFluxSupplier(supplier)) {
-			supplier = new FluxSupplier(supplier);
 		}
 		Flux<String> result = (Flux<String>) supplier.get();
 		return debug ? result.log() : result;

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxResponseBodyEmitter.java
@@ -46,8 +46,6 @@ class FluxResponseBodyEmitter<T> extends ResponseBodyEmitter {
 
 	@Override
 	protected void extendResponse(ServerHttpResponse outputMessage) {
-		super.extendResponse(outputMessage);
-
 		HttpHeaders headers = outputMessage.getHeaders();
 		if (headers.getContentType() == null && this.mediaType != null
 				&& !MediaType.ALL.equals(this.mediaType)) {

--- a/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxReturnValueHandler.java
+++ b/spring-cloud-function-web/src/main/java/org/springframework/cloud/function/web/flux/FluxReturnValueHandler.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.function.web.flux;
 import java.time.Duration;
 import java.util.List;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.reactivestreams.Publisher;
 
 import org.springframework.core.MethodParameter;
@@ -87,7 +89,10 @@ public class FluxReturnValueHandler implements AsyncHandlerMethodReturnValueHand
 			throws Exception {
 		Object adaptFrom = returnValue;
 		if (returnValue instanceof ResponseEntity) {
-			adaptFrom = ((ResponseEntity<?>) returnValue).getBody();
+			ResponseEntity<?> value = (ResponseEntity<?>) returnValue;
+			adaptFrom = value.getBody();
+			webRequest.getNativeResponse(HttpServletResponse.class)
+					.setStatus(value.getStatusCodeValue());
 		}
 		Publisher<?> flux = (Publisher<?>) adaptFrom;
 

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -166,6 +166,12 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void transform() {
+		assertThat(rest.postForObject("/transform", "foo\nbar", String.class))
+				.isEqualTo("[FOO][BAR]");
+	}
+
+	@Test
 	public void uppercaseGet() {
 		assertThat(rest.getForObject("/uppercase/foo", String.class)).isEqualTo("[FOO]");
 	}
@@ -222,7 +228,7 @@ public class RestApplicationTests {
 
 		private List<String> list = new ArrayList<>();
 
-		@Bean
+		@Bean({ "uppercase", "transform" })
 		public Function<Flux<String>, Flux<String>> uppercase() {
 			return flux -> flux.log()
 					.map(value -> "[" + value.trim().toUpperCase() + "]");

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -61,6 +61,8 @@ public class RestApplicationTests {
 	private int port;
 	@Autowired
 	private TestRestTemplate rest;
+	@Autowired
+	private TestConfiguration test;
 
 	@Test
 	public void wordsSSE() throws Exception {
@@ -98,8 +100,9 @@ public class RestApplicationTests {
 	public void updates() throws Exception {
 		ResponseEntity<String> result = rest.exchange(
 				RequestEntity.post(new URI("/updates")).body("one\ntwo"), String.class);
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(result.getBody()).isNull();
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+		assertThat(test.list).hasSize(2);
+		assertThat(result.getBody()).isEqualTo("onetwo");
 	}
 
 	@Test

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -97,6 +97,14 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void moreWords() throws Exception {
+		ResponseEntity<String> result = rest.exchange(
+				RequestEntity.get(new URI("/more/words")).build(), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("foobar");
+	}
+
+	@Test
 	public void updates() throws Exception {
 		ResponseEntity<String> result = rest.exchange(
 				RequestEntity.post(new URI("/updates")).body("one\ntwo"), String.class);
@@ -172,6 +180,18 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void postLongPath() {
+		assertThat(rest.postForObject("/get/more", "foo\nbar", String.class))
+				.isEqualTo("[FOO][BAR]");
+	}
+
+	@Test
+	public void longPath() {
+		assertThat(rest.getForObject("/get/more/stuff", String.class))
+				.isEqualTo("[STUFF]");
+	}
+
+	@Test
 	public void uppercaseGet() {
 		assertThat(rest.getForObject("/uppercase/foo", String.class)).isEqualTo("[FOO]");
 	}
@@ -228,7 +248,7 @@ public class RestApplicationTests {
 
 		private List<String> list = new ArrayList<>();
 
-		@Bean({ "uppercase", "transform" })
+		@Bean({ "uppercase", "transform", "get/more" })
 		public Function<Flux<String>, Flux<String>> uppercase() {
 			return flux -> flux.log()
 					.map(value -> "[" + value.trim().toUpperCase() + "]");
@@ -253,7 +273,7 @@ public class RestApplicationTests {
 			});
 		}
 
-		@Bean
+		@Bean({ "words", "more/words" })
 		public Supplier<Flux<String>> words() {
 			return () -> Flux.fromArray(new String[] { "foo", "bar" });
 		}


### PR DESCRIPTION
The function catalog now always wraps beans that deal with non-flux generic
types.

N.B. includes changes from #37. Also adds support for bean name aliases and
HTTP resource paths with slashes.