### PR TITLE
Extend support for simple types to Consumer and Supplier

### DIFF
--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/ConsumerProxy.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/ConsumerProxy.java
@@ -16,29 +16,18 @@
 
 package org.springframework.cloud.function.support;
 
-import java.util.function.Function;
-
-import reactor.core.publisher.Flux;
+import java.util.function.Consumer;
 
 /**
- * {@link Function} implementation that wraps a target Function so that the target's
- * simple input and output types will be wrapped as {@link Flux} instances.
- *
  * @author Mark Fisher
  *
- * @param <T> input type of target function
- * @param <R> output type of target function
+ * @param <T> output type of target Consumer
  */
-public class FluxFunction<T, R> implements Function<Flux<T>, Flux<R>> {
+public interface ConsumerProxy<T> extends Consumer<T> {
 
-	private final Function<T, R> function;
-
-	public FluxFunction(Function<T, R> function) {
-		this.function = function;
+	default boolean isFluxConsumer() {
+		return FunctionUtils.isFluxConsumer(getTarget());
 	}
 
-	@Override
-	public Flux<R> apply(Flux<T> input) {
-		return input.map(i -> this.function.apply(i));
-	}
+	Consumer<T> getTarget();
 }

--- a/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/FluxConsumer.java
+++ b/spring-cloud-function-core/src/main/java/org/springframework/cloud/function/support/FluxConsumer.java
@@ -16,29 +16,28 @@
 
 package org.springframework.cloud.function.support;
 
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import reactor.core.publisher.Flux;
 
 /**
- * {@link Function} implementation that wraps a target Function so that the target's
- * simple input and output types will be wrapped as {@link Flux} instances.
+ * {@link Consumer} implementation that wraps a target Consumer so that the target's
+ * simple input type will be wrapped as a {@link Flux} instance.
  *
- * @author Mark Fisher
+ * @author Dave Syer
  *
- * @param <T> input type of target function
- * @param <R> output type of target function
+ * @param <T> input type of target consumer
  */
-public class FluxFunction<T, R> implements Function<Flux<T>, Flux<R>> {
+public class FluxConsumer<T> implements Consumer<Flux<T>> {
 
-	private final Function<T, R> function;
+	private final Consumer<T> function;
 
-	public FluxFunction(Function<T, R> function) {
+	public FluxConsumer(Consumer<T> function) {
 		this.function = function;
 	}
 
 	@Override
-	public Flux<R> apply(Flux<T> input) {
-		return input.map(i -> this.function.apply(i));
+	public void accept(Flux<T> input) {
+		input.subscribe(t -> function.accept(t));
 	}
 }

--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -116,9 +116,27 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void bareWords() throws Exception {
+		ResponseEntity<String> result = rest
+				.exchange(RequestEntity.get(new URI("/bareWords")).build(), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).isEqualTo("foobar");
+	}
+
+	@Test
 	public void updates() throws Exception {
 		ResponseEntity<String> result = rest.exchange(
 				RequestEntity.post(new URI("/updates")).body("one\ntwo"), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+		assertThat(test.list).hasSize(2);
+		assertThat(result.getBody()).isEqualTo("onetwo");
+	}
+
+	@Test
+	public void bareUpdates() throws Exception {
+		ResponseEntity<String> result = rest.exchange(
+				RequestEntity.post(new URI("/bareUpdates")).body("one\ntwo"),
+				String.class);
 		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
 		assertThat(test.list).hasSize(2);
 		assertThat(result.getBody()).isEqualTo("onetwo");
@@ -181,6 +199,12 @@ public class RestApplicationTests {
 	@Test
 	public void uppercase() {
 		assertThat(rest.postForObject("/uppercase", "foo\nbar", String.class))
+				.isEqualTo("[FOO][BAR]");
+	}
+
+	@Test
+	public void bareUppercase() {
+		assertThat(rest.postForObject("/bareUppercase", "foo\nbar", String.class))
 				.isEqualTo("[FOO][BAR]");
 	}
 
@@ -271,6 +295,11 @@ public class RestApplicationTests {
 		}
 
 		@Bean
+		public Function<String, String> bareUppercase() {
+			return value -> "[" + value.trim().toUpperCase() + "]";
+		}
+
+		@Bean
 		public Function<Flux<Integer>, Flux<String>> wrap() {
 			return flux -> flux.log().map(value -> ".." + value + "..");
 		}
@@ -295,8 +324,18 @@ public class RestApplicationTests {
 		}
 
 		@Bean
+		public Supplier<List<String>> bareWords() {
+			return () -> Arrays.asList("foo", "bar");
+		}
+
+		@Bean
 		public Consumer<Flux<String>> updates() {
 			return flux -> flux.subscribe(value -> list.add(value));
+		}
+
+		@Bean
+		public Consumer<String> bareUpdates() {
+			return value -> list.add(value);
 		}
 
 		@Bean


### PR DESCRIPTION
The function catalog now always wraps beans that deal with non-flux
generic types.

Support for / separators (breaks static resources)

Use custom handler mapping to avoid clash with defaults

Add test for path prefix