### PR TITLE
Add support for explicit FunctionRegistration

### DIFF
--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -25,6 +25,10 @@
 			<version>${spring-cloud-function.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
@@ -32,6 +36,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionEntry.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionEntry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.function.registry.FunctionCatalog;
+import org.springframework.core.annotation.AliasFor;
+
+/**
+ * A {@link Qualifier} annotation that specifies how to locate a function in the
+ * {@link FunctionCatalog} (instead of using the bean name).
+ *
+ * @author Dave Syer
+ */
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE,
+		ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@Qualifier
+public @interface FunctionEntry {
+	@AliasFor(annotation=Qualifier.class)
+	String value() default "";
+}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionRegistration.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionRegistration.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class FunctionRegistration<T> {
+
+	private T target;
+
+	private Set<String> names = new LinkedHashSet<>();
+
+	private Map<String, String> properties = new LinkedHashMap<>();
+
+	public FunctionRegistration() {
+	}
+
+	public FunctionRegistration(T target) {
+		this.target = target;
+	}
+
+	public Map<String, String> getProperties() {
+		return properties;
+	}
+
+	public Set<String> getNames() {
+		return names;
+	}
+
+	public void setNames(Set<String> names) {
+		this.names = names;
+	}
+
+	public T getTarget() {
+		return target;
+	}
+
+	public FunctionRegistration<T> properties(Map<String, String> properties) {
+		this.properties.putAll(properties);
+		return this;
+	}
+
+	public FunctionRegistration<T> target(T target) {
+		this.target = target;
+		return this;
+	}
+
+	public FunctionRegistration<T> name(String name) {
+		this.names.add(name);
+		return this;
+	}
+
+	public FunctionRegistration<T> names(Collection<String> names) {
+		this.names.addAll(names);
+		return this;
+	}
+
+	public FunctionRegistration<T> names(String... names) {
+		this.names.addAll(Arrays.asList(names));
+		return this;
+	}
+
+}

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/InMemoryFunctionCatalog.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/InMemoryFunctionCatalog.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.function.context;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -41,6 +43,29 @@ public class InMemoryFunctionCatalog implements FunctionCatalog {
 		this.suppliers = suppliers;
 		this.functions = functions;
 		this.consumers = consumers;
+	}
+
+	public InMemoryFunctionCatalog(Set<FunctionRegistration<?>> registrations) {
+		this.suppliers = new HashMap<>();
+		this.functions = new HashMap<>();
+		this.consumers = new HashMap<>();
+		for (FunctionRegistration<?> registration : registrations) {
+			if (registration.getTarget() instanceof Consumer) {
+				for (String name : registration.getNames()) {
+					consumers.put(name, (Consumer<?>) registration.getTarget());
+				}
+			}
+			if (registration.getTarget() instanceof Supplier) {
+				for (String name : registration.getNames()) {
+					suppliers.put(name, (Supplier<?>) registration.getTarget());
+				}
+			}
+			if (registration.getTarget() instanceof Function) {
+				for (String name : registration.getNames()) {
+					functions.put(name, (Function<?, ?>) registration.getTarget());
+				}
+			}
+		}
 	}
 
 	@Override

--- a/spring-cloud-function-context/test/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfigurationTests.java
+++ b/spring-cloud-function-context/test/java/org/springframework/cloud/function/context/ContextFunctionCatalogAutoConfigurationTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.context;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class ContextFunctionCatalogAutoConfigurationTests {
+
+	private ConfigurableApplicationContext context;
+	private InMemoryFunctionCatalog catalog;
+
+	@After
+	public void close() {
+		if (context != null) {
+			context.close();
+		}
+	}
+
+	@Test
+	public void simpleFunction() {
+		create(SimpleConfiguration.class);
+		assertThat(context.getBean("function")).isInstanceOf(Function.class);
+		assertThat(catalog.lookupFunction("function")).isInstanceOf(Function.class);
+	}
+
+	@Test
+	public void simpleSupplier() {
+		create(SimpleConfiguration.class);
+		assertThat(context.getBean("supplier")).isInstanceOf(Supplier.class);
+		Supplier<Flux<String>> supplier = catalog.lookupSupplier("supplier");
+		assertThat(supplier.get().blockFirst()).isEqualTo("hello");
+	}
+
+	@Test
+	public void simpleConsumer() {
+		create(SimpleConfiguration.class);
+		assertThat(context.getBean("consumer")).isInstanceOf(Consumer.class);
+		Consumer<Flux<String>> consumer = catalog.lookupConsumer("consumer");
+		consumer.accept(Flux.just("foo", "bar"));
+		assertThat(context.getBean(SimpleConfiguration.class).list).hasSize(2);
+	}
+
+	@Test
+	public void qualifiedBean() {
+		create(QualifiedConfiguration.class);
+		assertThat(context.getBean("function")).isInstanceOf(Function.class);
+		assertThat(catalog.lookupFunction("function")).isNull();
+		assertThat(catalog.lookupFunction("other")).isInstanceOf(Function.class);
+	}
+
+	@Test
+	public void aliasBean() {
+		create(AliasConfiguration.class);
+		assertThat(context.getBean("function")).isInstanceOf(Function.class);
+		assertThat(catalog.lookupFunction("function")).isNotNull();
+		assertThat(catalog.lookupFunction("other")).isInstanceOf(Function.class);
+	}
+
+	@Test
+	public void registrationBean() {
+		create(RegistrationConfiguration.class);
+		assertThat(context.getBean("function")).isInstanceOf(Function.class);
+		assertThat(catalog.lookupFunction("function")).isNull();
+		assertThat(catalog.lookupFunction("registration")).isNull();
+		assertThat(catalog.lookupFunction("other")).isInstanceOf(Function.class);
+	}
+
+	private void create(Class<?>... types) {
+		context = new SpringApplicationBuilder((Object[]) types).run();
+		catalog = context.getBean(InMemoryFunctionCatalog.class);
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class SimpleConfiguration {
+		private List<String> list = new ArrayList<>();
+		@Bean
+		public Function<String, String> function() {
+			return value -> value.toUpperCase();
+		}
+		@Bean
+		public Supplier<String> supplier() {
+			return () -> "hello";
+		}
+		@Bean
+		public Consumer<String> consumer() {
+			return value -> list.add(value);
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class QualifiedConfiguration {
+		@Bean
+		@Qualifier("other")
+		public Function<String, String> function() {
+			return value -> value.toUpperCase();
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class AliasConfiguration {
+		@Bean({"function", "other"})
+		public Function<String, String> function() {
+			return value -> value.toUpperCase();
+		}
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	protected static class RegistrationConfiguration {
+		@Bean
+		public FunctionRegistration<Function<String, String>> registration() {
+			return new FunctionRegistration<Function<String, String>>(function()).name("other");
+		}
+		@Bean
+		public Function<String, String> function() {
+			return value -> value.toUpperCase();
+		}
+	}
+
+}


### PR DESCRIPTION
A bean of type FunctionRegistration registers the function with
user-specified name and other properties, rather than relying on the
bean name.
    
Alternatively, function catalog keys can be specified as a
@Qualifier, which will be used instead of the bean name if
no registration is found.
