### PR TITLE
Fix JSON conversion of non flux functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<reactor-bom.version>Aluminium-SR1</reactor-bom.version>
-		<spring-cloud-stream.version>Chelsea.BUILD-SNAPSHOT</spring-cloud-stream.version>
+		<reactor-bom.version>Aluminium-BUILD-SNAPSHOT</reactor-bom.version>
+		<spring-cloud-stream.version>Chelsea.SR1</spring-cloud-stream.version>
 		<wrapper.version>1.0.0.RELEASE</wrapper.version>
 		<spring-boot.version>1.5.2.RELEASE</spring-boot.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<java.version>1.8</java.version>
 		<reactor-bom.version>Aluminium-SR1</reactor-bom.version>
 		<spring-cloud-stream.version>Chelsea.BUILD-SNAPSHOT</spring-cloud-stream.version>
-		<wrapper.version>1.0.0.RC1</wrapper.version>
+		<wrapper.version>1.0.0.RELEASE</wrapper.version>
 		<spring-boot.version>1.5.2.RELEASE</spring-boot.version>
 	</properties>
 

--- a/spring-cloud-function-deployer/pom.xml
+++ b/spring-cloud-function-deployer/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 
 	<properties>
-		<spring-cloud-deployer-thin.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-thin.version>
+		<spring-cloud-deployer-thin.version>1.0.0.RELEASE</spring-cloud-deployer-thin.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-function-samples/spring-cloud-function-sample-compiler/pom.xml
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-compiler/pom.xml
@@ -20,8 +20,8 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
-		<wrapper.version>1.0.0.M2</wrapper.version>
-		<reactor.version>3.0.4.RELEASE</reactor.version>
+		<wrapper.version>1.0.0.RELEASE</wrapper.version>
+		<reactor.version>3.0.6.RELEASE</reactor.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-function-samples/spring-cloud-function-sample-pojo/pom.xml
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-pojo/pom.xml
@@ -20,8 +20,8 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
-		<wrapper.version>1.0.0.M2</wrapper.version>
-		<reactor.version>3.0.5.RELEASE</reactor.version>
+		<wrapper.version>1.0.0.RELEASE</wrapper.version>
+		<reactor.version>3.0.6.RELEASE</reactor.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-function-samples/spring-cloud-function-sample-pojo/pom.xml
+++ b/spring-cloud-function-samples/spring-cloud-function-sample-pojo/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>1.8</java.version>
 		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<wrapper.version>1.0.0.RELEASE</wrapper.version>
-		<reactor.version>3.0.6.RELEASE</reactor.version>
+		<reactor.version>3.0.7.BUILD-SNAPSHOT</reactor.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-function-samples/spring-cloud-function-sample/pom.xml
+++ b/spring-cloud-function-samples/spring-cloud-function-sample/pom.xml
@@ -21,7 +21,7 @@
 		<java.version>1.8</java.version>
 		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
 		<wrapper.version>1.0.0.RELEASE</wrapper.version>
-		<reactor.version>3.0.5.RELEASE</reactor.version>
+		<reactor.version>3.0.7.BUILD-SNAPSHOT</reactor.version>
 	</properties>
 
 	<dependencies>

--- a/spring-cloud-function-samples/spring-cloud-function-sample/pom.xml
+++ b/spring-cloud-function-samples/spring-cloud-function-sample/pom.xml
@@ -13,14 +13,14 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.1.RELEASE</version>
+		<version>1.5.2.RELEASE</version>
 		<relativePath/>
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
 		<spring-cloud-function.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-function.version>
-		<wrapper.version>1.0.0.M2</wrapper.version>
+		<wrapper.version>1.0.0.RELEASE</wrapper.version>
 		<reactor.version>3.0.5.RELEASE</reactor.version>
 	</properties>
 

--- a/spring-cloud-function-stream/pom.xml
+++ b/spring-cloud-function-stream/pom.xml
@@ -46,6 +46,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-binder-rabbit</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
@@ -66,7 +66,7 @@ public class FluxPojoStreamingConsumerTests {
 
 		@Bean
 		public Consumer<Flux<String>> sinkConsumer(final List<String> sinkCollector) {
-			return foos -> foos.doOnNext(s -> sinkCollector.add(s));
+			return foos -> foos.subscribe(s -> sinkCollector.add(s));
 		}
 	}
 

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxPojoStreamingConsumerTests.java
@@ -33,14 +33,16 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import reactor.core.publisher.Flux;
+
 /**
  * @author Marius Bogoevici
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = StreamingConsumerTests.StreamingSinkTest.class, properties = {
+@SpringBootTest(classes = FluxPojoStreamingConsumerTests.StreamingSinkTest.class, properties = {
 		"spring.cloud.stream.bindings.input.destination=data-in",
 		"spring.cloud.function.stream.endpoint=sinkConsumer" })
-public class StreamingConsumerTests {
+public class FluxPojoStreamingConsumerTests {
 
 	@Autowired
 	Sink sink;
@@ -51,7 +53,7 @@ public class StreamingConsumerTests {
 	@Test
 	public void test() throws Exception {
 		sink.input().send(MessageBuilder.withPayload("foo").build());
-		assertThat(sinkCollector).containsExactly("foo");
+		assertThat(sinkCollector).hasSize(1);
 	}
 
 	@SpringBootApplication
@@ -63,8 +65,9 @@ public class StreamingConsumerTests {
 		}
 
 		@Bean
-		public Consumer<String> sinkConsumer(final List<String> sinkCollector) {
-			return s -> sinkCollector.add(s);
+		public Consumer<Flux<String>> sinkConsumer(final List<String> sinkCollector) {
+			return foos -> foos.doOnNext(s -> sinkCollector.add(s));
 		}
 	}
+
 }

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/FluxStreamingConsumerTests.java
@@ -52,7 +52,7 @@ public class FluxStreamingConsumerTests {
 
 	@Test
 	public void test() throws Exception {
-		sink.input().send(MessageBuilder.withPayload(new Foo("foo")).build());
+		sink.input().send(MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
 		assertThat(sinkCollector).hasSize(1);
 	}
 

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
@@ -50,7 +50,7 @@ public class PojoStreamingConsumerTests {
 
 	@Test
 	public void test() throws Exception {
-		sink.input().send(MessageBuilder.withPayload(new Foo("foo")).build());
+		sink.input().send(MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
 		assertThat(sinkCollector).hasSize(1);
 	}
 

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/consumer/PojoStreamingConsumerTests.java
@@ -37,34 +37,53 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Marius Bogoevici
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = StreamingConsumerTests.StreamingSinkTest.class, properties = {
+@SpringBootTest(classes = PojoStreamingConsumerTests.StreamingSinkTest.class, properties = {
 		"spring.cloud.stream.bindings.input.destination=data-in",
 		"spring.cloud.function.stream.endpoint=sinkConsumer" })
-public class StreamingConsumerTests {
+public class PojoStreamingConsumerTests {
 
 	@Autowired
 	Sink sink;
 
 	@Autowired
-	List<String> sinkCollector;
+	List<Foo> sinkCollector;
 
 	@Test
 	public void test() throws Exception {
-		sink.input().send(MessageBuilder.withPayload("foo").build());
-		assertThat(sinkCollector).containsExactly("foo");
+		sink.input().send(MessageBuilder.withPayload(new Foo("foo")).build());
+		assertThat(sinkCollector).hasSize(1);
 	}
 
 	@SpringBootApplication
 	public static class StreamingSinkTest {
 
 		@Bean
-		public List<String> sinkCollector() {
+		public List<Foo> sinkCollector() {
 			return new ArrayList<>();
 		}
 
 		@Bean
-		public Consumer<String> sinkConsumer(final List<String> sinkCollector) {
+		public Consumer<Foo> sinkConsumer(final List<Foo> sinkCollector) {
 			return s -> sinkCollector.add(s);
+		}
+	}
+
+	protected static class Foo {
+		private String name;
+
+		Foo() {
+		}
+
+		public Foo(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
 		}
 	}
 }


### PR DESCRIPTION
36c6b2d (Dave Syer, 33 minutes ago)
Update versions of boot things

70dff6b (Marius Bogoevici, 7 days ago)
Enable JSON conversion for non-Flux functions
    - use ProxyWrapper around a FluxConsumer as well
     making it consistent with the behaviour of Flux
     functions
    - Enable introspection for scanned beans
    - Fix failing tests by passing JSON string as input messages
     (marshalled form expected from the binder)

d1cf9b4 (Dave Syer, 7 days ago)
Add some failing tests