### PR TITLE
Add support for POSTing a single POJO

### DIFF
--- a/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
+++ b/spring-cloud-function-web/src/test/java/org/springframework/cloud/function/web/RestApplicationTests.java
@@ -274,6 +274,16 @@ public class RestApplicationTests {
 	}
 
 	@Test
+	public void uppercaseFoo() throws Exception {
+		// Single Foo can be parsed
+		ResponseEntity<String> result = rest.exchange(RequestEntity
+				.post(new URI("/upFoos")).contentType(MediaType.APPLICATION_JSON)
+				.body("{\"value\":\"foo\"}"), String.class);
+		assertThat(result.getBody())
+				.isEqualTo("[{\"value\":\"FOO\"}]");
+	}
+
+	@Test
 	public void bareUppercase() throws Exception {
 		ResponseEntity<String> result = rest.exchange(RequestEntity
 				.post(new URI("/bareUppercase")).contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
You need to cache the request body so it can be read twice, once
to see if it's an array, and again to turn it into a POJO.