### PR TITLE
Add support for Message<Foo> in stream apps

### DIFF
--- a/spring-cloud-function-context/pom.xml
+++ b/spring-cloud-function-context/pom.xml
@@ -29,6 +29,10 @@
 			<artifactId>spring-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-messaging</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 		</dependency>

--- a/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionInspector.java
+++ b/spring-cloud-function-context/src/main/java/org/springframework/cloud/function/context/FunctionInspector.java
@@ -28,6 +28,8 @@ import reactor.core.publisher.Mono;
  */
 public interface FunctionInspector {
 
+	boolean isMessage(String name);
+
 	Class<?> getInputType(String name);
 
 	Class<?> getOutputType(String name);

--- a/spring-cloud-function-deployer/src/main/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalog.java
+++ b/spring-cloud-function-deployer/src/main/java/org/springframework/cloud/function/deployer/FunctionExtractingFunctionCatalog.java
@@ -30,7 +30,8 @@ import org.springframework.cloud.function.context.FunctionInspector;
 import org.springframework.cloud.function.registry.FunctionCatalog;
 import org.springframework.util.MethodInvoker;
 
-public class FunctionExtractingFunctionCatalog implements FunctionCatalog, FunctionInspector {
+public class FunctionExtractingFunctionCatalog
+		implements FunctionCatalog, FunctionInspector {
 
 	private static Log logger = LogFactory
 			.getLog(FunctionExtractingFunctionCatalog.class);
@@ -63,6 +64,11 @@ public class FunctionExtractingFunctionCatalog implements FunctionCatalog, Funct
 	@Override
 	public <T> Supplier<T> lookupSupplier(String name) {
 		return (Supplier<T>) lookup(name, "lookupSupplier");
+	}
+
+	@Override
+	public boolean isMessage(String name) {
+		return (Boolean) inspect(name, "isMessage");
 	}
 
 	@Override
@@ -112,14 +118,14 @@ public class FunctionExtractingFunctionCatalog implements FunctionCatalog, Funct
 		}
 		return invoke(FunctionInspector.class, method, arg);
 	}
-	
+
 	private Object lookup(String name, String method) {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Looking up " + name + " with " + method);
 		}
 		return invoke(FunctionCatalog.class, method, name);
 	}
-	
+
 	private Object invoke(Class<?> type, String method, Object arg) {
 		for (String id : deployed) {
 			Object catalog = deployer.getBean(id, type);

--- a/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/StreamListeningConsumerInvoker.java
+++ b/spring-cloud-function-stream/src/main/java/org/springframework/cloud/function/stream/StreamListeningConsumerInvoker.java
@@ -93,7 +93,10 @@ public class StreamListeningConsumerInvoker implements SmartInitializingSingleto
 	private Function<Message<?>, Object> convertInput(String name) {
 		Class<?> inputType = functionInspector.getInputType(name);
 		return m -> {
-			if (inputType.isAssignableFrom(m.getPayload().getClass())) {
+			if (Message.class.isAssignableFrom(inputType)) {
+				return m;
+			}
+			else if (inputType.isAssignableFrom(m.getPayload().getClass())) {
 				return m.getPayload();
 			}
 			else {

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/function/FluxMessagePojoStreamingFunctionTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/function/FluxMessagePojoStreamingFunctionTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.stream.function;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = FluxMessagePojoStreamingFunctionTests.StreamingFunctionApplication.class)
+public class FluxMessagePojoStreamingFunctionTests {
+
+	@Autowired
+	Processor processor;
+
+	@Autowired
+	MessageCollector messageCollector;
+
+	@Test
+	public void test() throws Exception {
+		processor.input().send(
+				MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
+		Message<?> result = messageCollector.forChannel(processor.output()).poll(1000,
+				TimeUnit.MILLISECONDS);
+		assertThat(result.getPayload()).isInstanceOf(Foo.class);
+	}
+
+	@SpringBootApplication
+	public static class StreamingFunctionApplication {
+
+		@Bean
+		public Function<Flux<Message<Foo>>, Flux<Message<Foo>>> uppercase() {
+			return flux -> flux.map(f -> MessageBuilder
+					.withPayload(new Foo(f.getPayload().getName().toUpperCase()))
+					.build());
+		}
+	}
+
+	protected static class Foo {
+		private String name;
+
+		Foo() {
+		}
+
+		public Foo(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}

--- a/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/function/MessagePojoStreamingFunctionTests.java
+++ b/spring-cloud-function-stream/src/test/java/org/springframework/cloud/function/stream/function/MessagePojoStreamingFunctionTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.stream.function;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.messaging.Processor;
+import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Marius Bogoevici
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = MessagePojoStreamingFunctionTests.StreamingFunctionApplication.class)
+public class MessagePojoStreamingFunctionTests {
+
+	@Autowired
+	Processor processor;
+
+	@Autowired
+	MessageCollector messageCollector;
+
+	@Test
+	public void test() throws Exception {
+		processor.input().send(
+				MessageBuilder.withPayload(new String("{\"name\":\"foo\"}")).build());
+		Message<?> result = messageCollector.forChannel(processor.output()).poll(1000,
+				TimeUnit.MILLISECONDS);
+		assertThat(result.getPayload()).isInstanceOf(Foo.class);
+	}
+
+	@SpringBootApplication
+	public static class StreamingFunctionApplication {
+
+		@Bean
+		public Function<Message<Foo>, Message<Foo>> uppercase() {
+			return f -> MessageBuilder
+					.withPayload(new Foo(f.getPayload().getName().toUpperCase())).build();
+		}
+	}
+
+	protected static class Foo {
+		private String name;
+
+		Foo() {
+		}
+
+		public Foo(String name) {
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+}


### PR DESCRIPTION
The FunctionInspector needs to be able to distinguish between a
function of Flux<Foo> and a function of Flux<Message<Foo>>. Then
it can do the conversion a level below.

Only supports Message->Message or POJO->POJO (no mixtures), so there
is only one new method in FunctionInspector.

No support in the web endpoints yet. But it's probably not so hard
to add.

See #58 