### PR TITLE
Update openwhisk README to make it clearer how to run it

### DIFF
--- a/spring-cloud-function-adapters/spring-cloud-function-adapter-openwhisk/README.md
+++ b/spring-cloud-function-adapters/spring-cloud-function-adapter-openwhisk/README.md
@@ -1,4 +1,4 @@
-Implement a POF:
+Implement a POF (be sure to use the `functions` package):
 
 ```
 package functions;
@@ -22,7 +22,7 @@ Install it into your local Maven repository:
 Create a `function.properties` file that provides its Maven coordinates. For example:
 
 ```
-dependencies.function: io.spring.sample:uppercase-function:0.0.1-SNAPSHOT
+dependencies.function: com.example:pof:0.0.1-SNAPSHOT
 ```
 
 Copy the openwhisk runner JAR to the working directory (same directory as the properties file):
@@ -34,22 +34,23 @@ cp spring-cloud-function-adapters/spring-cloud-function-adapter-openwhisk/target
 Generate a m2 repo from the `--thin.dryrun` of the runner JAR with the above properties file:
 
 ```
-java -jar runner.jar --thin.root=m2 --thin.name=function --thin.dryrun
+java -jar -Dthin.root=m2 runner.jar --thin.name=function --thin.dryrun
 ```
 
 Use the following Dockerfile:
 
 ```
-FROM openjdk:8
-
+FROM openjdk:8-jdk-alpine
+VOLUME /tmp
 COPY m2 /m2
 ADD runner.jar .
 ADD function.properties .
-
-ENTRYPOINT [ "sh", "-c", "java -Djava.security.egd=file:/dev/./urandom -jar runner.jar --thin.root=/m2 --thin.name=function --function.name=uppercase" ]
-
+ENV JAVA_OPTS=""
+ENTRYPOINT [ "java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "runner.jar", "--thin.root=/m2", "--thin.name=function", "--function.name=uppercase"]
 EXPOSE 8080
 ```
+
+> NOTE: you cloud use a Spring Cloud Function app, instead of just a jar with a POF in it, in which case you would have to change the way the app runs in the container so that it picks up the main class as a source file. For example, you could change the `ENTRYPOINT` above and add `--spring.main.sources=com.example.SampleApplication`.
 
 Build the Docker image:
 
@@ -66,13 +67,13 @@ docker push [username/appname]
 Use the OpenWhisk CLI (e.g. after `vagrant ssh`) to create the action:
 
 ```
-wsk action create --docker example [username/appname]
+wsk action create example --docker [username/appname]
 ```
 
 Invoke the action:
 
 ```
-wsk action invoke --result example --param payload foo
+wsk action invoke example --result --param payload foo
 {
     "result": "FOO"
 }


### PR DESCRIPTION
The io.spring sample referred to in the openwhisk README isn't
in this repo, so users generally don't have it installed locally.
This change switches to make it more explicit what to do to
create it.

Also fixes the `wsk ...` command lines (the order of arguments
was wrong - maybe the CLI changed?).